### PR TITLE
Removed unused npm tools

### DIFF
--- a/03-bridge-agent/src/node/agent.js
+++ b/03-bridge-agent/src/node/agent.js
@@ -1,10 +1,3 @@
-var http = require('http');
-var express = require('express');
-var path = require('path');
-var favicon = require('serve-favicon');
-var logger = require('morgan');
-var cookieParser = require('cookie-parser');
-var bodyParser = require('body-parser');
 
 // initialize the event bus when we initialize the server
 var EventBus = require('vertx3-eventbus-client');


### PR DESCRIPTION
They are actually not managed in the package.json file so they are not present in node_modules and thus prevent the node app from starting.