### PR TITLE
Upgrade to 3.7.1

### DIFF
--- a/01-polling-dashboard/src/main/java/polling/dashboard/Server.java
+++ b/01-polling-dashboard/src/main/java/polling/dashboard/Server.java
@@ -46,7 +46,7 @@ public class Server extends AbstractVerticle {
     });
 
     vertx.createHttpServer()
-      .requestHandler(router::accept)
+      .requestHandler(router)
       .listen(8080);
   }
 }

--- a/02-push-agent/src/main/resources/cluster.xml
+++ b/02-push-agent/src/main/resources/cluster.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc.
+  ~
+  ~ Red Hat licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
+           xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <properties>
+    <property name="hazelcast.mancenter.enabled">false</property>
+    <property name="hazelcast.memcache.enabled">false</property>
+    <property name="hazelcast.rest.enabled">false</property>
+    <property name="hazelcast.wait.seconds.before.join">5</property>
+  </properties>
+
+  <group>
+    <name>dev</name>
+    <password>dev-pass</password>
+  </group>
+  <management-center enabled="false">http://localhost:8080/mancenter</management-center>
+  <network>
+    <port auto-increment="true" port-count="10000">5701</port>
+    <outbound-ports>
+      <!--
+      Allowed port range when connecting to other nodes.
+      0 or * means use system provided port.
+      -->
+      <ports>0</ports>
+    </outbound-ports>
+    <join>
+      <multicast enabled="true" loopbackModeEnabled="true">
+        <multicast-group>224.2.2.3</multicast-group>
+        <multicast-port>54327</multicast-port>
+      </multicast>
+      <tcp-ip enabled="false">
+        <interface>192.168.1.28</interface>
+      </tcp-ip>
+      <aws enabled="false">
+        <access-key>my-access-key</access-key>
+        <secret-key>my-secret-key</secret-key>
+        <!--optional, default is us-east-1 -->
+        <region>us-west-1</region>
+        <!--optional, default is ec2.amazonaws.com. If set, region shouldn't be set as it will override this property -->
+        <host-header>ec2.amazonaws.com</host-header>
+        <!-- optional, only instances belonging to this group will be discovered, default will try all running instances -->
+        <security-group-name>hazelcast-sg</security-group-name>
+        <tag-key>type</tag-key>
+        <tag-value>hz-nodes</tag-value>
+      </aws>
+    </join>
+    <interfaces enabled="false">
+      <interface>10.10.1.*</interface>
+    </interfaces>
+    <ssl enabled="false"/>
+    <socket-interceptor enabled="false"/>
+    <symmetric-encryption enabled="false">
+      <!--
+         encryption algorithm such as
+         DES/ECB/PKCS5Padding,
+         PBEWithMD5AndDES,
+         AES/CBC/PKCS5Padding,
+         Blowfish,
+         DESede
+      -->
+      <algorithm>PBEWithMD5AndDES</algorithm>
+      <!-- salt value to use when generating the secret key -->
+      <salt>thesalt</salt>
+      <!-- pass phrase to use when generating the secret key -->
+      <password>thepass</password>
+      <!-- iteration count to use when generating the secret key -->
+      <iteration-count>19</iteration-count>
+    </symmetric-encryption>
+  </network>
+  <partition-group enabled="false"/>
+  <executor-service name="default">
+    <pool-size>16</pool-size>
+    <!--Queue capacity. 0 means Integer.MAX_VALUE.-->
+    <queue-capacity>0</queue-capacity>
+  </executor-service>
+
+  <multimap name="__vertx.subs">
+
+    <!--
+        Number of backups. If 1 is set as the backup-count for example,
+        then all entries of the map will be copied to another JVM for
+        fail-safety. 0 means no backup.
+    -->
+    <backup-count>1</backup-count>
+  </multimap>
+
+  <map name="__vertx.haInfo">
+
+    <!--
+        Number of backups. If 1 is set as the backup-count for example,
+        then all entries of the map will be copied to another JVM for
+        fail-safety. 0 means no backup.
+    -->
+    <backup-count>1</backup-count>
+    <!--
+  Maximum number of seconds for each entry to stay in the map. Entries that are
+  older than <time-to-live-seconds> and not updated for <time-to-live-seconds>
+  will get automatically evicted from the map.
+  Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+-->
+    <time-to-live-seconds>0</time-to-live-seconds>
+    <!--
+  Maximum number of seconds for each entry to stay idle in the map. Entries that are
+  idle(not touched) for more than <max-idle-seconds> will get
+  automatically evicted from the map. Entry is touched if get, put or containsKey is called.
+  Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+-->
+    <max-idle-seconds>0</max-idle-seconds>
+    <!--
+        Valid values are:
+        NONE (no eviction),
+        LRU (Least Recently Used),
+        LFU (Least Frequently Used).
+        NONE is the default.
+    -->
+    <eviction-policy>NONE</eviction-policy>
+    <!--
+        Maximum size of the map. When max size is reached,
+        map is evicted based on the policy defined.
+        Any integer between 0 and Integer.MAX_VALUE. 0 means
+        Integer.MAX_VALUE. Default is 0.
+    -->
+    <max-size policy="PER_NODE">0</max-size>
+    <!--
+        When max. size is reached, specified percentage of
+        the map will be evicted. Any integer between 0 and 100.
+        If 25 is set for example, 25% of the entries will
+        get evicted.
+    -->
+    <eviction-percentage>25</eviction-percentage>
+    <!--
+        While recovering from split-brain (network partitioning),
+        map entries in the small cluster will merge into the bigger cluster
+        based on the policy set here. When an entry merge into the
+        cluster, there might an existing entry with the same key already.
+        Values of these entries might be different for that same key.
+        Which value should be set for the key? Conflict is resolved by
+        the policy set here. Default policy is PutIfAbsentMapMergePolicy
+
+        There are built-in merge policies such as
+        com.hazelcast.map.merge.PassThroughMergePolicy; entry will be added if there is no existing entry for the key.
+        com.hazelcast.map.merge.PutIfAbsentMapMergePolicy ; entry will be added if the merging entry doesn't exist in the cluster.
+        com.hazelcast.map.merge.HigherHitsMapMergePolicy ; entry with the higher hits wins.
+        com.hazelcast.map.merge.LatestUpdateMapMergePolicy ; entry with the latest update wins.
+    -->
+    <merge-policy>com.hazelcast.map.merge.LatestUpdateMapMergePolicy</merge-policy>
+
+  </map>
+
+  <!-- Used internally in Vert.x to implement async locks -->
+  <semaphore name="__vertx.*">
+    <initial-permits>1</initial-permits>
+  </semaphore>
+
+</hazelcast>

--- a/02-push-dashboard/src/main/java/push/dashboard/Server.java
+++ b/02-push-dashboard/src/main/java/push/dashboard/Server.java
@@ -43,7 +43,7 @@ public class Server extends AbstractVerticle {
 
 
     vertx.createHttpServer()
-      .requestHandler(router::accept)
+      .requestHandler(router)
       .listen(8080);
   }
 }

--- a/02-push-dashboard/src/main/resources/cluster.xml
+++ b/02-push-dashboard/src/main/resources/cluster.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc.
+  ~
+  ~ Red Hat licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
+           xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <properties>
+    <property name="hazelcast.mancenter.enabled">false</property>
+    <property name="hazelcast.memcache.enabled">false</property>
+    <property name="hazelcast.rest.enabled">false</property>
+    <property name="hazelcast.wait.seconds.before.join">5</property>
+  </properties>
+
+  <group>
+    <name>dev</name>
+    <password>dev-pass</password>
+  </group>
+  <management-center enabled="false">http://localhost:8080/mancenter</management-center>
+  <network>
+    <port auto-increment="true" port-count="10000">5701</port>
+    <outbound-ports>
+      <!--
+      Allowed port range when connecting to other nodes.
+      0 or * means use system provided port.
+      -->
+      <ports>0</ports>
+    </outbound-ports>
+    <join>
+      <multicast enabled="true" loopbackModeEnabled="true">
+        <multicast-group>224.2.2.3</multicast-group>
+        <multicast-port>54327</multicast-port>
+      </multicast>
+      <tcp-ip enabled="false">
+        <interface>192.168.1.28</interface>
+      </tcp-ip>
+      <aws enabled="false">
+        <access-key>my-access-key</access-key>
+        <secret-key>my-secret-key</secret-key>
+        <!--optional, default is us-east-1 -->
+        <region>us-west-1</region>
+        <!--optional, default is ec2.amazonaws.com. If set, region shouldn't be set as it will override this property -->
+        <host-header>ec2.amazonaws.com</host-header>
+        <!-- optional, only instances belonging to this group will be discovered, default will try all running instances -->
+        <security-group-name>hazelcast-sg</security-group-name>
+        <tag-key>type</tag-key>
+        <tag-value>hz-nodes</tag-value>
+      </aws>
+    </join>
+    <interfaces enabled="false">
+      <interface>10.10.1.*</interface>
+    </interfaces>
+    <ssl enabled="false"/>
+    <socket-interceptor enabled="false"/>
+    <symmetric-encryption enabled="false">
+      <!--
+         encryption algorithm such as
+         DES/ECB/PKCS5Padding,
+         PBEWithMD5AndDES,
+         AES/CBC/PKCS5Padding,
+         Blowfish,
+         DESede
+      -->
+      <algorithm>PBEWithMD5AndDES</algorithm>
+      <!-- salt value to use when generating the secret key -->
+      <salt>thesalt</salt>
+      <!-- pass phrase to use when generating the secret key -->
+      <password>thepass</password>
+      <!-- iteration count to use when generating the secret key -->
+      <iteration-count>19</iteration-count>
+    </symmetric-encryption>
+  </network>
+  <partition-group enabled="false"/>
+  <executor-service name="default">
+    <pool-size>16</pool-size>
+    <!--Queue capacity. 0 means Integer.MAX_VALUE.-->
+    <queue-capacity>0</queue-capacity>
+  </executor-service>
+
+  <multimap name="__vertx.subs">
+
+    <!--
+        Number of backups. If 1 is set as the backup-count for example,
+        then all entries of the map will be copied to another JVM for
+        fail-safety. 0 means no backup.
+    -->
+    <backup-count>1</backup-count>
+  </multimap>
+
+  <map name="__vertx.haInfo">
+
+    <!--
+        Number of backups. If 1 is set as the backup-count for example,
+        then all entries of the map will be copied to another JVM for
+        fail-safety. 0 means no backup.
+    -->
+    <backup-count>1</backup-count>
+    <!--
+  Maximum number of seconds for each entry to stay in the map. Entries that are
+  older than <time-to-live-seconds> and not updated for <time-to-live-seconds>
+  will get automatically evicted from the map.
+  Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+-->
+    <time-to-live-seconds>0</time-to-live-seconds>
+    <!--
+  Maximum number of seconds for each entry to stay idle in the map. Entries that are
+  idle(not touched) for more than <max-idle-seconds> will get
+  automatically evicted from the map. Entry is touched if get, put or containsKey is called.
+  Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+-->
+    <max-idle-seconds>0</max-idle-seconds>
+    <!--
+        Valid values are:
+        NONE (no eviction),
+        LRU (Least Recently Used),
+        LFU (Least Frequently Used).
+        NONE is the default.
+    -->
+    <eviction-policy>NONE</eviction-policy>
+    <!--
+        Maximum size of the map. When max size is reached,
+        map is evicted based on the policy defined.
+        Any integer between 0 and Integer.MAX_VALUE. 0 means
+        Integer.MAX_VALUE. Default is 0.
+    -->
+    <max-size policy="PER_NODE">0</max-size>
+    <!--
+        When max. size is reached, specified percentage of
+        the map will be evicted. Any integer between 0 and 100.
+        If 25 is set for example, 25% of the entries will
+        get evicted.
+    -->
+    <eviction-percentage>25</eviction-percentage>
+    <!--
+        While recovering from split-brain (network partitioning),
+        map entries in the small cluster will merge into the bigger cluster
+        based on the policy set here. When an entry merge into the
+        cluster, there might an existing entry with the same key already.
+        Values of these entries might be different for that same key.
+        Which value should be set for the key? Conflict is resolved by
+        the policy set here. Default policy is PutIfAbsentMapMergePolicy
+
+        There are built-in merge policies such as
+        com.hazelcast.map.merge.PassThroughMergePolicy; entry will be added if there is no existing entry for the key.
+        com.hazelcast.map.merge.PutIfAbsentMapMergePolicy ; entry will be added if the merging entry doesn't exist in the cluster.
+        com.hazelcast.map.merge.HigherHitsMapMergePolicy ; entry with the higher hits wins.
+        com.hazelcast.map.merge.LatestUpdateMapMergePolicy ; entry with the latest update wins.
+    -->
+    <merge-policy>com.hazelcast.map.merge.LatestUpdateMapMergePolicy</merge-policy>
+
+  </map>
+
+  <!-- Used internally in Vert.x to implement async locks -->
+  <semaphore name="__vertx.*">
+    <initial-permits>1</initial-permits>
+  </semaphore>
+
+</hazelcast>

--- a/03-bridge-agent/src/main/resources/cluster.xml
+++ b/03-bridge-agent/src/main/resources/cluster.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc.
+  ~
+  ~ Red Hat licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
+           xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <properties>
+    <property name="hazelcast.mancenter.enabled">false</property>
+    <property name="hazelcast.memcache.enabled">false</property>
+    <property name="hazelcast.rest.enabled">false</property>
+    <property name="hazelcast.wait.seconds.before.join">5</property>
+  </properties>
+
+  <group>
+    <name>dev</name>
+    <password>dev-pass</password>
+  </group>
+  <management-center enabled="false">http://localhost:8080/mancenter</management-center>
+  <network>
+    <port auto-increment="true" port-count="10000">5701</port>
+    <outbound-ports>
+      <!--
+      Allowed port range when connecting to other nodes.
+      0 or * means use system provided port.
+      -->
+      <ports>0</ports>
+    </outbound-ports>
+    <join>
+      <multicast enabled="true" loopbackModeEnabled="true">
+        <multicast-group>224.2.2.3</multicast-group>
+        <multicast-port>54327</multicast-port>
+      </multicast>
+      <tcp-ip enabled="false">
+        <interface>192.168.1.28</interface>
+      </tcp-ip>
+      <aws enabled="false">
+        <access-key>my-access-key</access-key>
+        <secret-key>my-secret-key</secret-key>
+        <!--optional, default is us-east-1 -->
+        <region>us-west-1</region>
+        <!--optional, default is ec2.amazonaws.com. If set, region shouldn't be set as it will override this property -->
+        <host-header>ec2.amazonaws.com</host-header>
+        <!-- optional, only instances belonging to this group will be discovered, default will try all running instances -->
+        <security-group-name>hazelcast-sg</security-group-name>
+        <tag-key>type</tag-key>
+        <tag-value>hz-nodes</tag-value>
+      </aws>
+    </join>
+    <interfaces enabled="false">
+      <interface>10.10.1.*</interface>
+    </interfaces>
+    <ssl enabled="false"/>
+    <socket-interceptor enabled="false"/>
+    <symmetric-encryption enabled="false">
+      <!--
+         encryption algorithm such as
+         DES/ECB/PKCS5Padding,
+         PBEWithMD5AndDES,
+         AES/CBC/PKCS5Padding,
+         Blowfish,
+         DESede
+      -->
+      <algorithm>PBEWithMD5AndDES</algorithm>
+      <!-- salt value to use when generating the secret key -->
+      <salt>thesalt</salt>
+      <!-- pass phrase to use when generating the secret key -->
+      <password>thepass</password>
+      <!-- iteration count to use when generating the secret key -->
+      <iteration-count>19</iteration-count>
+    </symmetric-encryption>
+  </network>
+  <partition-group enabled="false"/>
+  <executor-service name="default">
+    <pool-size>16</pool-size>
+    <!--Queue capacity. 0 means Integer.MAX_VALUE.-->
+    <queue-capacity>0</queue-capacity>
+  </executor-service>
+
+  <multimap name="__vertx.subs">
+
+    <!--
+        Number of backups. If 1 is set as the backup-count for example,
+        then all entries of the map will be copied to another JVM for
+        fail-safety. 0 means no backup.
+    -->
+    <backup-count>1</backup-count>
+  </multimap>
+
+  <map name="__vertx.haInfo">
+
+    <!--
+        Number of backups. If 1 is set as the backup-count for example,
+        then all entries of the map will be copied to another JVM for
+        fail-safety. 0 means no backup.
+    -->
+    <backup-count>1</backup-count>
+    <!--
+  Maximum number of seconds for each entry to stay in the map. Entries that are
+  older than <time-to-live-seconds> and not updated for <time-to-live-seconds>
+  will get automatically evicted from the map.
+  Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+-->
+    <time-to-live-seconds>0</time-to-live-seconds>
+    <!--
+  Maximum number of seconds for each entry to stay idle in the map. Entries that are
+  idle(not touched) for more than <max-idle-seconds> will get
+  automatically evicted from the map. Entry is touched if get, put or containsKey is called.
+  Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+-->
+    <max-idle-seconds>0</max-idle-seconds>
+    <!--
+        Valid values are:
+        NONE (no eviction),
+        LRU (Least Recently Used),
+        LFU (Least Frequently Used).
+        NONE is the default.
+    -->
+    <eviction-policy>NONE</eviction-policy>
+    <!--
+        Maximum size of the map. When max size is reached,
+        map is evicted based on the policy defined.
+        Any integer between 0 and Integer.MAX_VALUE. 0 means
+        Integer.MAX_VALUE. Default is 0.
+    -->
+    <max-size policy="PER_NODE">0</max-size>
+    <!--
+        When max. size is reached, specified percentage of
+        the map will be evicted. Any integer between 0 and 100.
+        If 25 is set for example, 25% of the entries will
+        get evicted.
+    -->
+    <eviction-percentage>25</eviction-percentage>
+    <!--
+        While recovering from split-brain (network partitioning),
+        map entries in the small cluster will merge into the bigger cluster
+        based on the policy set here. When an entry merge into the
+        cluster, there might an existing entry with the same key already.
+        Values of these entries might be different for that same key.
+        Which value should be set for the key? Conflict is resolved by
+        the policy set here. Default policy is PutIfAbsentMapMergePolicy
+
+        There are built-in merge policies such as
+        com.hazelcast.map.merge.PassThroughMergePolicy; entry will be added if there is no existing entry for the key.
+        com.hazelcast.map.merge.PutIfAbsentMapMergePolicy ; entry will be added if the merging entry doesn't exist in the cluster.
+        com.hazelcast.map.merge.HigherHitsMapMergePolicy ; entry with the higher hits wins.
+        com.hazelcast.map.merge.LatestUpdateMapMergePolicy ; entry with the latest update wins.
+    -->
+    <merge-policy>com.hazelcast.map.merge.LatestUpdateMapMergePolicy</merge-policy>
+
+  </map>
+
+  <!-- Used internally in Vert.x to implement async locks -->
+  <semaphore name="__vertx.*">
+    <initial-permits>1</initial-permits>
+  </semaphore>
+
+</hazelcast>

--- a/03-bridge-dashboard/src/main/java/bridge/dashboard/Server.java
+++ b/03-bridge-dashboard/src/main/java/bridge/dashboard/Server.java
@@ -61,7 +61,7 @@ public class Server extends AbstractVerticle {
 
 
     vertx.createHttpServer()
-      .requestHandler(router::accept)
+      .requestHandler(router)
       .listen(8080);
   }
 }

--- a/03-bridge-dashboard/src/main/resources/cluster.xml
+++ b/03-bridge-dashboard/src/main/resources/cluster.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc.
+  ~
+  ~ Red Hat licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
+           xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <properties>
+    <property name="hazelcast.mancenter.enabled">false</property>
+    <property name="hazelcast.memcache.enabled">false</property>
+    <property name="hazelcast.rest.enabled">false</property>
+    <property name="hazelcast.wait.seconds.before.join">5</property>
+  </properties>
+
+  <group>
+    <name>dev</name>
+    <password>dev-pass</password>
+  </group>
+  <management-center enabled="false">http://localhost:8080/mancenter</management-center>
+  <network>
+    <port auto-increment="true" port-count="10000">5701</port>
+    <outbound-ports>
+      <!--
+      Allowed port range when connecting to other nodes.
+      0 or * means use system provided port.
+      -->
+      <ports>0</ports>
+    </outbound-ports>
+    <join>
+      <multicast enabled="true" loopbackModeEnabled="true">
+        <multicast-group>224.2.2.3</multicast-group>
+        <multicast-port>54327</multicast-port>
+      </multicast>
+      <tcp-ip enabled="false">
+        <interface>192.168.1.28</interface>
+      </tcp-ip>
+      <aws enabled="false">
+        <access-key>my-access-key</access-key>
+        <secret-key>my-secret-key</secret-key>
+        <!--optional, default is us-east-1 -->
+        <region>us-west-1</region>
+        <!--optional, default is ec2.amazonaws.com. If set, region shouldn't be set as it will override this property -->
+        <host-header>ec2.amazonaws.com</host-header>
+        <!-- optional, only instances belonging to this group will be discovered, default will try all running instances -->
+        <security-group-name>hazelcast-sg</security-group-name>
+        <tag-key>type</tag-key>
+        <tag-value>hz-nodes</tag-value>
+      </aws>
+    </join>
+    <interfaces enabled="false">
+      <interface>10.10.1.*</interface>
+    </interfaces>
+    <ssl enabled="false"/>
+    <socket-interceptor enabled="false"/>
+    <symmetric-encryption enabled="false">
+      <!--
+         encryption algorithm such as
+         DES/ECB/PKCS5Padding,
+         PBEWithMD5AndDES,
+         AES/CBC/PKCS5Padding,
+         Blowfish,
+         DESede
+      -->
+      <algorithm>PBEWithMD5AndDES</algorithm>
+      <!-- salt value to use when generating the secret key -->
+      <salt>thesalt</salt>
+      <!-- pass phrase to use when generating the secret key -->
+      <password>thepass</password>
+      <!-- iteration count to use when generating the secret key -->
+      <iteration-count>19</iteration-count>
+    </symmetric-encryption>
+  </network>
+  <partition-group enabled="false"/>
+  <executor-service name="default">
+    <pool-size>16</pool-size>
+    <!--Queue capacity. 0 means Integer.MAX_VALUE.-->
+    <queue-capacity>0</queue-capacity>
+  </executor-service>
+
+  <multimap name="__vertx.subs">
+
+    <!--
+        Number of backups. If 1 is set as the backup-count for example,
+        then all entries of the map will be copied to another JVM for
+        fail-safety. 0 means no backup.
+    -->
+    <backup-count>1</backup-count>
+  </multimap>
+
+  <map name="__vertx.haInfo">
+
+    <!--
+        Number of backups. If 1 is set as the backup-count for example,
+        then all entries of the map will be copied to another JVM for
+        fail-safety. 0 means no backup.
+    -->
+    <backup-count>1</backup-count>
+    <!--
+  Maximum number of seconds for each entry to stay in the map. Entries that are
+  older than <time-to-live-seconds> and not updated for <time-to-live-seconds>
+  will get automatically evicted from the map.
+  Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+-->
+    <time-to-live-seconds>0</time-to-live-seconds>
+    <!--
+  Maximum number of seconds for each entry to stay idle in the map. Entries that are
+  idle(not touched) for more than <max-idle-seconds> will get
+  automatically evicted from the map. Entry is touched if get, put or containsKey is called.
+  Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+-->
+    <max-idle-seconds>0</max-idle-seconds>
+    <!--
+        Valid values are:
+        NONE (no eviction),
+        LRU (Least Recently Used),
+        LFU (Least Frequently Used).
+        NONE is the default.
+    -->
+    <eviction-policy>NONE</eviction-policy>
+    <!--
+        Maximum size of the map. When max size is reached,
+        map is evicted based on the policy defined.
+        Any integer between 0 and Integer.MAX_VALUE. 0 means
+        Integer.MAX_VALUE. Default is 0.
+    -->
+    <max-size policy="PER_NODE">0</max-size>
+    <!--
+        When max. size is reached, specified percentage of
+        the map will be evicted. Any integer between 0 and 100.
+        If 25 is set for example, 25% of the entries will
+        get evicted.
+    -->
+    <eviction-percentage>25</eviction-percentage>
+    <!--
+        While recovering from split-brain (network partitioning),
+        map entries in the small cluster will merge into the bigger cluster
+        based on the policy set here. When an entry merge into the
+        cluster, there might an existing entry with the same key already.
+        Values of these entries might be different for that same key.
+        Which value should be set for the key? Conflict is resolved by
+        the policy set here. Default policy is PutIfAbsentMapMergePolicy
+
+        There are built-in merge policies such as
+        com.hazelcast.map.merge.PassThroughMergePolicy; entry will be added if there is no existing entry for the key.
+        com.hazelcast.map.merge.PutIfAbsentMapMergePolicy ; entry will be added if the merging entry doesn't exist in the cluster.
+        com.hazelcast.map.merge.HigherHitsMapMergePolicy ; entry with the higher hits wins.
+        com.hazelcast.map.merge.LatestUpdateMapMergePolicy ; entry with the latest update wins.
+    -->
+    <merge-policy>com.hazelcast.map.merge.LatestUpdateMapMergePolicy</merge-policy>
+
+  </map>
+
+  <!-- Used internally in Vert.x to implement async locks -->
+  <semaphore name="__vertx.*">
+    <initial-permits>1</initial-permits>
+  </semaphore>
+
+</hazelcast>

--- a/04-rx-agent/src/main/resources/cluster.xml
+++ b/04-rx-agent/src/main/resources/cluster.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc.
+  ~
+  ~ Red Hat licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
+           xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <properties>
+    <property name="hazelcast.mancenter.enabled">false</property>
+    <property name="hazelcast.memcache.enabled">false</property>
+    <property name="hazelcast.rest.enabled">false</property>
+    <property name="hazelcast.wait.seconds.before.join">5</property>
+  </properties>
+
+  <group>
+    <name>dev</name>
+    <password>dev-pass</password>
+  </group>
+  <management-center enabled="false">http://localhost:8080/mancenter</management-center>
+  <network>
+    <port auto-increment="true" port-count="10000">5701</port>
+    <outbound-ports>
+      <!--
+      Allowed port range when connecting to other nodes.
+      0 or * means use system provided port.
+      -->
+      <ports>0</ports>
+    </outbound-ports>
+    <join>
+      <multicast enabled="true" loopbackModeEnabled="true">
+        <multicast-group>224.2.2.3</multicast-group>
+        <multicast-port>54327</multicast-port>
+      </multicast>
+      <tcp-ip enabled="false">
+        <interface>192.168.1.28</interface>
+      </tcp-ip>
+      <aws enabled="false">
+        <access-key>my-access-key</access-key>
+        <secret-key>my-secret-key</secret-key>
+        <!--optional, default is us-east-1 -->
+        <region>us-west-1</region>
+        <!--optional, default is ec2.amazonaws.com. If set, region shouldn't be set as it will override this property -->
+        <host-header>ec2.amazonaws.com</host-header>
+        <!-- optional, only instances belonging to this group will be discovered, default will try all running instances -->
+        <security-group-name>hazelcast-sg</security-group-name>
+        <tag-key>type</tag-key>
+        <tag-value>hz-nodes</tag-value>
+      </aws>
+    </join>
+    <interfaces enabled="false">
+      <interface>10.10.1.*</interface>
+    </interfaces>
+    <ssl enabled="false"/>
+    <socket-interceptor enabled="false"/>
+    <symmetric-encryption enabled="false">
+      <!--
+         encryption algorithm such as
+         DES/ECB/PKCS5Padding,
+         PBEWithMD5AndDES,
+         AES/CBC/PKCS5Padding,
+         Blowfish,
+         DESede
+      -->
+      <algorithm>PBEWithMD5AndDES</algorithm>
+      <!-- salt value to use when generating the secret key -->
+      <salt>thesalt</salt>
+      <!-- pass phrase to use when generating the secret key -->
+      <password>thepass</password>
+      <!-- iteration count to use when generating the secret key -->
+      <iteration-count>19</iteration-count>
+    </symmetric-encryption>
+  </network>
+  <partition-group enabled="false"/>
+  <executor-service name="default">
+    <pool-size>16</pool-size>
+    <!--Queue capacity. 0 means Integer.MAX_VALUE.-->
+    <queue-capacity>0</queue-capacity>
+  </executor-service>
+
+  <multimap name="__vertx.subs">
+
+    <!--
+        Number of backups. If 1 is set as the backup-count for example,
+        then all entries of the map will be copied to another JVM for
+        fail-safety. 0 means no backup.
+    -->
+    <backup-count>1</backup-count>
+  </multimap>
+
+  <map name="__vertx.haInfo">
+
+    <!--
+        Number of backups. If 1 is set as the backup-count for example,
+        then all entries of the map will be copied to another JVM for
+        fail-safety. 0 means no backup.
+    -->
+    <backup-count>1</backup-count>
+    <!--
+  Maximum number of seconds for each entry to stay in the map. Entries that are
+  older than <time-to-live-seconds> and not updated for <time-to-live-seconds>
+  will get automatically evicted from the map.
+  Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+-->
+    <time-to-live-seconds>0</time-to-live-seconds>
+    <!--
+  Maximum number of seconds for each entry to stay idle in the map. Entries that are
+  idle(not touched) for more than <max-idle-seconds> will get
+  automatically evicted from the map. Entry is touched if get, put or containsKey is called.
+  Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+-->
+    <max-idle-seconds>0</max-idle-seconds>
+    <!--
+        Valid values are:
+        NONE (no eviction),
+        LRU (Least Recently Used),
+        LFU (Least Frequently Used).
+        NONE is the default.
+    -->
+    <eviction-policy>NONE</eviction-policy>
+    <!--
+        Maximum size of the map. When max size is reached,
+        map is evicted based on the policy defined.
+        Any integer between 0 and Integer.MAX_VALUE. 0 means
+        Integer.MAX_VALUE. Default is 0.
+    -->
+    <max-size policy="PER_NODE">0</max-size>
+    <!--
+        When max. size is reached, specified percentage of
+        the map will be evicted. Any integer between 0 and 100.
+        If 25 is set for example, 25% of the entries will
+        get evicted.
+    -->
+    <eviction-percentage>25</eviction-percentage>
+    <!--
+        While recovering from split-brain (network partitioning),
+        map entries in the small cluster will merge into the bigger cluster
+        based on the policy set here. When an entry merge into the
+        cluster, there might an existing entry with the same key already.
+        Values of these entries might be different for that same key.
+        Which value should be set for the key? Conflict is resolved by
+        the policy set here. Default policy is PutIfAbsentMapMergePolicy
+
+        There are built-in merge policies such as
+        com.hazelcast.map.merge.PassThroughMergePolicy; entry will be added if there is no existing entry for the key.
+        com.hazelcast.map.merge.PutIfAbsentMapMergePolicy ; entry will be added if the merging entry doesn't exist in the cluster.
+        com.hazelcast.map.merge.HigherHitsMapMergePolicy ; entry with the higher hits wins.
+        com.hazelcast.map.merge.LatestUpdateMapMergePolicy ; entry with the latest update wins.
+    -->
+    <merge-policy>com.hazelcast.map.merge.LatestUpdateMapMergePolicy</merge-policy>
+
+  </map>
+
+  <!-- Used internally in Vert.x to implement async locks -->
+  <semaphore name="__vertx.*">
+    <initial-permits>1</initial-permits>
+  </semaphore>
+
+</hazelcast>

--- a/04-rx-dashboard/src/main/java/rx/dashboard/Server.java
+++ b/04-rx-dashboard/src/main/java/rx/dashboard/Server.java
@@ -6,7 +6,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.bridge.PermittedOptions;
 import io.vertx.ext.web.handler.sockjs.BridgeOptions;
 import io.vertx.reactivex.core.AbstractVerticle;
-import io.vertx.reactivex.core.Vertx;
 import io.vertx.reactivex.core.eventbus.Message;
 import io.vertx.reactivex.ext.web.Router;
 import io.vertx.reactivex.ext.web.handler.StaticHandler;
@@ -62,7 +61,7 @@ public class Server extends AbstractVerticle {
 
 
     vertx.createHttpServer()
-      .requestHandler(router::accept)
+      .requestHandler(router)
       .listen(8080);
   }
 }

--- a/04-rx-dashboard/src/main/resources/cluster.xml
+++ b/04-rx-dashboard/src/main/resources/cluster.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc.
+  ~
+  ~ Red Hat licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
+           xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <properties>
+    <property name="hazelcast.mancenter.enabled">false</property>
+    <property name="hazelcast.memcache.enabled">false</property>
+    <property name="hazelcast.rest.enabled">false</property>
+    <property name="hazelcast.wait.seconds.before.join">5</property>
+  </properties>
+
+  <group>
+    <name>dev</name>
+    <password>dev-pass</password>
+  </group>
+  <management-center enabled="false">http://localhost:8080/mancenter</management-center>
+  <network>
+    <port auto-increment="true" port-count="10000">5701</port>
+    <outbound-ports>
+      <!--
+      Allowed port range when connecting to other nodes.
+      0 or * means use system provided port.
+      -->
+      <ports>0</ports>
+    </outbound-ports>
+    <join>
+      <multicast enabled="true" loopbackModeEnabled="true">
+        <multicast-group>224.2.2.3</multicast-group>
+        <multicast-port>54327</multicast-port>
+      </multicast>
+      <tcp-ip enabled="false">
+        <interface>192.168.1.28</interface>
+      </tcp-ip>
+      <aws enabled="false">
+        <access-key>my-access-key</access-key>
+        <secret-key>my-secret-key</secret-key>
+        <!--optional, default is us-east-1 -->
+        <region>us-west-1</region>
+        <!--optional, default is ec2.amazonaws.com. If set, region shouldn't be set as it will override this property -->
+        <host-header>ec2.amazonaws.com</host-header>
+        <!-- optional, only instances belonging to this group will be discovered, default will try all running instances -->
+        <security-group-name>hazelcast-sg</security-group-name>
+        <tag-key>type</tag-key>
+        <tag-value>hz-nodes</tag-value>
+      </aws>
+    </join>
+    <interfaces enabled="false">
+      <interface>10.10.1.*</interface>
+    </interfaces>
+    <ssl enabled="false"/>
+    <socket-interceptor enabled="false"/>
+    <symmetric-encryption enabled="false">
+      <!--
+         encryption algorithm such as
+         DES/ECB/PKCS5Padding,
+         PBEWithMD5AndDES,
+         AES/CBC/PKCS5Padding,
+         Blowfish,
+         DESede
+      -->
+      <algorithm>PBEWithMD5AndDES</algorithm>
+      <!-- salt value to use when generating the secret key -->
+      <salt>thesalt</salt>
+      <!-- pass phrase to use when generating the secret key -->
+      <password>thepass</password>
+      <!-- iteration count to use when generating the secret key -->
+      <iteration-count>19</iteration-count>
+    </symmetric-encryption>
+  </network>
+  <partition-group enabled="false"/>
+  <executor-service name="default">
+    <pool-size>16</pool-size>
+    <!--Queue capacity. 0 means Integer.MAX_VALUE.-->
+    <queue-capacity>0</queue-capacity>
+  </executor-service>
+
+  <multimap name="__vertx.subs">
+
+    <!--
+        Number of backups. If 1 is set as the backup-count for example,
+        then all entries of the map will be copied to another JVM for
+        fail-safety. 0 means no backup.
+    -->
+    <backup-count>1</backup-count>
+  </multimap>
+
+  <map name="__vertx.haInfo">
+
+    <!--
+        Number of backups. If 1 is set as the backup-count for example,
+        then all entries of the map will be copied to another JVM for
+        fail-safety. 0 means no backup.
+    -->
+    <backup-count>1</backup-count>
+    <!--
+  Maximum number of seconds for each entry to stay in the map. Entries that are
+  older than <time-to-live-seconds> and not updated for <time-to-live-seconds>
+  will get automatically evicted from the map.
+  Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+-->
+    <time-to-live-seconds>0</time-to-live-seconds>
+    <!--
+  Maximum number of seconds for each entry to stay idle in the map. Entries that are
+  idle(not touched) for more than <max-idle-seconds> will get
+  automatically evicted from the map. Entry is touched if get, put or containsKey is called.
+  Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+-->
+    <max-idle-seconds>0</max-idle-seconds>
+    <!--
+        Valid values are:
+        NONE (no eviction),
+        LRU (Least Recently Used),
+        LFU (Least Frequently Used).
+        NONE is the default.
+    -->
+    <eviction-policy>NONE</eviction-policy>
+    <!--
+        Maximum size of the map. When max size is reached,
+        map is evicted based on the policy defined.
+        Any integer between 0 and Integer.MAX_VALUE. 0 means
+        Integer.MAX_VALUE. Default is 0.
+    -->
+    <max-size policy="PER_NODE">0</max-size>
+    <!--
+        When max. size is reached, specified percentage of
+        the map will be evicted. Any integer between 0 and 100.
+        If 25 is set for example, 25% of the entries will
+        get evicted.
+    -->
+    <eviction-percentage>25</eviction-percentage>
+    <!--
+        While recovering from split-brain (network partitioning),
+        map entries in the small cluster will merge into the bigger cluster
+        based on the policy set here. When an entry merge into the
+        cluster, there might an existing entry with the same key already.
+        Values of these entries might be different for that same key.
+        Which value should be set for the key? Conflict is resolved by
+        the policy set here. Default policy is PutIfAbsentMapMergePolicy
+
+        There are built-in merge policies such as
+        com.hazelcast.map.merge.PassThroughMergePolicy; entry will be added if there is no existing entry for the key.
+        com.hazelcast.map.merge.PutIfAbsentMapMergePolicy ; entry will be added if the merging entry doesn't exist in the cluster.
+        com.hazelcast.map.merge.HigherHitsMapMergePolicy ; entry with the higher hits wins.
+        com.hazelcast.map.merge.LatestUpdateMapMergePolicy ; entry with the latest update wins.
+    -->
+    <merge-policy>com.hazelcast.map.merge.LatestUpdateMapMergePolicy</merge-policy>
+
+  </map>
+
+  <!-- Used internally in Vert.x to implement async locks -->
+  <semaphore name="__vertx.*">
+    <initial-permits>1</initial-permits>
+  </semaphore>
+
+</hazelcast>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <vertx.version>3.5.4</vertx.version>
+    <vertx.version>3.7.1</vertx.version>
     <main.verticle>io.vertx.starter.MainVerticle</main.verticle>
   </properties>
 


### PR DESCRIPTION
- vertx version update in root POM
- router API simplification
- loopback mode no longer enabled by default in Hazelcast 3.10 (useful while presenting)